### PR TITLE
Método de acesso ao controlador de movimentação alterado

### DIFF
--- a/Scripts/Movement/Movement.gd
+++ b/Scripts/Movement/Movement.gd
@@ -1,7 +1,6 @@
 extends Node
 
 onready var body = get_parent()
-onready var controller = get_child(0) # TODO: improve this access to controlle child node
 
 export (int) var speed = 100
 export (int) var jump_speed = 200
@@ -15,7 +14,7 @@ func _physics_process(delta):
 	move()
 
 func apply_controller_movement():
-	velocity = controller.get_input(Vector2(0, velocity.y))
+	velocity = $Controller.get_input(Vector2(0, velocity.y))
 
 func apply_gravity(delta):
 	velocity.y += gravity * delta

--- a/Utils/KeyboardMovement.tscn
+++ b/Utils/KeyboardMovement.tscn
@@ -6,5 +6,5 @@
 [node name="Movement" type="Node2D"]
 script = ExtResource( 1 )
 
-[node name="KeyboardController" type="Node2D" parent="."]
+[node name="Controller" type="Node2D" parent="."]
 script = ExtResource( 2 )


### PR DESCRIPTION
Agora usando o símbolo `$` do GDScript para acessar o nó filho. Além disso, o nome do nó foi padronizado para `Controller`, sendo necessário o uso desse nome.

A cena que matém a estrutura `/Utils/KeyboardMovement.tscn` também foi alterada para manter a transparência no uso da implementação.