### PR TITLE
Health patch

### DIFF
--- a/Objects/Players/Elf.tscn
+++ b/Objects/Players/Elf.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Scripts/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f0.png" type="Texture" id=2]
@@ -11,6 +11,7 @@
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f2.png" type="Texture" id=9]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
+[ext_resource path="res://Utils/Health.tscn" type="PackedScene" id=12]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 5.81073
@@ -44,7 +45,8 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
-frame = 1
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]
+
+[node name="Health" parent="." instance=ExtResource( 12 )]

--- a/Objects/Players/Knight.tscn
+++ b/Objects/Players/Knight.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Scripts/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_idle_anim_f0.png" type="Texture" id=2]
@@ -11,6 +11,7 @@
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f2.png" type="Texture" id=9]
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
+[ext_resource path="res://Utils/Health.tscn" type="PackedScene" id=12]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 6.06816
@@ -44,6 +45,9 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
+frame = 1
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]
+
+[node name="Health" parent="." instance=ExtResource( 12 )]

--- a/Objects/Players/Lizard.tscn
+++ b/Objects/Players/Lizard.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Scripts/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_idle_anim_f0.png" type="Texture" id=2]
@@ -11,6 +11,7 @@
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f2.png" type="Texture" id=9]
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
+[ext_resource path="res://Utils/Health.tscn" type="PackedScene" id=12]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 6.04267
@@ -48,3 +49,5 @@ frame = 1
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]
+
+[node name="Health" parent="." instance=ExtResource( 12 )]

--- a/Objects/Players/Wizard.tscn
+++ b/Objects/Players/Wizard.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Scripts/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_idle_anim_f0.png" type="Texture" id=2]
@@ -11,6 +11,7 @@
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f2.png" type="Texture" id=9]
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
+[ext_resource path="res://Utils/Health.tscn" type="PackedScene" id=12]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 5.74877
@@ -44,7 +45,9 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
-frame = 3
+frame = 1
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]
+
+[node name="Health" parent="." instance=ExtResource( 12 )]

--- a/Scripts/Health/Health.gd
+++ b/Scripts/Health/Health.gd
@@ -4,40 +4,57 @@ export (int) var current_hp = 1
 export (int) var max_hp = 1
 
 func set_max_hp(value:int):
-	max_hp=value
-	if current_hp>max_hp:
-		current_hp=max_hp
-
-func set_current_hp(value:int):
-	if current_hp+value>max_hp:
-		current_hp=max_hp
+	if value<0:
+		print_debug("tentativa de setar o hp maximo para um valor negativo")
 	else:
-		current_hp=value
-
-func reduce_current_hp(value:int):
-	if value>current_hp:
-		current_hp=0
-	else:
-		current_hp-=value
-
-func reduce_max_hp(value:int):
-	if value>=max_hp:
-		return false
-	else:
-		max_hp-=value
+		max_hp=value
 		if current_hp>max_hp:
 			current_hp=max_hp
 
+func set_current_hp(value:int):
+	if value<0:
+		print_debug("tentativa de setar o hp para um valor negativo")
+	else:
+		if current_hp+value>max_hp:
+			current_hp=max_hp
+		else:
+			current_hp=value
+
+func reduce_current_hp(value:int):
+	if value<0:
+		print_debug("tentativa de reduzir o hp com um valor negativo")
+	else:
+		if value>current_hp:
+			current_hp=0
+		else:
+			current_hp-=value
+
+func reduce_max_hp(value:int):
+	if value<0:
+		print_debug("tentativa de reduzir o hp maximo com um valor negativo")
+	else:
+		if value>=max_hp:
+			print_debug("tentativa de reduzir o hp para um valor <0")
+		else:
+			max_hp-=value
+			if current_hp>max_hp:
+				current_hp=max_hp
 
 func increase_current_hp(value:int):
-	if value+current_hp>max_hp:
-		current_hp=max_hp
+	if value<0:
+		print_debug("tentativa de aumentar o hp com um valor negativo")
 	else:
-		current_hp+=value
+		if value+current_hp>max_hp:
+			current_hp=max_hp
+		else:
+			current_hp+=value
 
 func increase_max_hp(value:int):
-	max_hp+=value
-	current_hp+=value
+	if value<0:
+		print_debug("tentativa de aumentar o hp maximo por um valor negativo")
+	else:
+		max_hp+=value
+		current_hp+=value
 
 func reset_hp():
 	current_hp=0

--- a/Scripts/Health/Health.gd
+++ b/Scripts/Health/Health.gd
@@ -1,0 +1,42 @@
+extends Node
+
+export (int) var current_hp = 1
+export (int) var max_hp = 1
+
+func set_max_hp(value:int):
+	max_hp=value
+	if current_hp>max_hp:
+		current_hp=max_hp
+
+func set_current_hp(value:int):
+	if current_hp+value>max_hp:
+		return false
+	else:
+		current_hp=value
+
+func reduce_current_hp(value:int):
+	if value>current_hp:
+		current_hp=0
+	else:
+		current_hp-=value
+
+func reduce_max_hp(value:int):
+	if value>=max_hp:
+		return false
+	else:
+		max_hp-=value
+		if current_hp>max_hp:
+			current_hp=max_hp
+
+
+func increase_current_hp(value:int):
+	if value+current_hp>max_hp:
+		current_hp=max_hp
+	else:
+		current_hp+=value
+
+func increase_max_hp(value:int):
+	max_hp+=value
+
+func reset_hp():
+	current_hp=0

--- a/Scripts/Health/Health.gd
+++ b/Scripts/Health/Health.gd
@@ -10,7 +10,7 @@ func set_max_hp(value:int):
 
 func set_current_hp(value:int):
 	if current_hp+value>max_hp:
-		return false
+		current_hp=max_hp
 	else:
 		current_hp=value
 
@@ -37,6 +37,7 @@ func increase_current_hp(value:int):
 
 func increase_max_hp(value:int):
 	max_hp+=value
+	current_hp+=value
 
 func reset_hp():
 	current_hp=0

--- a/Scripts/Health/HealthController.gd
+++ b/Scripts/Health/HealthController.gd
@@ -1,0 +1,6 @@
+extends Node
+
+#func _ready():
+#	pass
+#func _process(delta):
+#	pass

--- a/Scripts/Health/HealthController.gd
+++ b/Scripts/Health/HealthController.gd
@@ -1,6 +1,0 @@
-extends Node
-
-#func _ready():
-#	pass
-#func _process(delta):
-#	pass

--- a/Utils/Health.tscn
+++ b/Utils/Health.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Scripts/Health/Health.gd" type="Script" id=1]
+[ext_resource path="res://Scripts/Health/HealthController.gd" type="Script" id=2]
+
+[node name="Health" type="Node2D"]
+script = ExtResource( 1 )
+
+[node name="Controller" type="Node2D" parent="."]
+script = ExtResource( 2 )

--- a/Utils/Health.tscn
+++ b/Utils/Health.tscn
@@ -1,10 +1,6 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://Scripts/Health/Health.gd" type="Script" id=1]
-[ext_resource path="res://Scripts/Health/HealthController.gd" type="Script" id=2]
 
 [node name="Health" type="Node2D"]
 script = ExtResource( 1 )
-
-[node name="Controller" type="Node2D" parent="."]
-script = ExtResource( 2 )


### PR DESCRIPTION
As alterações já foram implementadas aos objetos dos players. É possível realizar testes apenas diretamente pelos scripts. Segue uma explicação do script implementado.

# Health.gd
É responsável por controlar o HP de qualquer objeto que possua esta propriedade. Este script guarda os valores e é o único a manipulá-los, em resposta a gatilhos externos. Possui apenas duas variáveis: current_hp e max_hp, sendo estas, respectivamente, a resistência atual e máxima do objeto em questão.
Todas as funções, com exceção de ```reset_hp()``` possue um único argumento "value", que é informado durante a interação com outros objetos, e define o valor a ser alterado nas variáveis de hp. **Nenhuma das funções aceita números negativos como atributo**. As tarefas realizadas por este script são:

- ```set_max_hp()```: definir um valor para ```max_hp```, conferindo se o novo valor de ```max_hp``` é menor que ```current_hp```, alterando ```current_hp``` conforme necessário;
- ```set_current_hp()```: definir um valor para ```current_hp```, conferindo se este valor é maior que ```max_hp```;
- ```increase_current_hp()```: aumentar ```current_hp``` de acordo com o valor especificado, limitando-o a max_hp;
- ```increase_max_hp()```: aumentar ```max_hp``` de acordo com o valor especificado;
- ```reduce_max_hp()```: diminuir ```max_hp``` de acordo com o valor especificado. Também altera ```current_hp``` caso o novo valor de ```max_hp``` seja menor que ```current_hp```;
- ```reduce_current_hp()```: diminuir ```current_hp```, não permitindo que o valor torne-se menor que 0;
- ```reset_hp()```: altera o valor de ```current_hp``` para 0.

## Estrutura
O script encontra-se em um nó do tipo ```Node2D```, que existe somente para mantê-lo. Este foi armazenado em uma cena na localização ```/Utils/Health.tscn```