### PR TITLE
Attack patch

### DIFF
--- a/Objects/Foes/Demons/DemonBatedor.tscn
+++ b/Objects/Foes/Demons/DemonBatedor.tscn
@@ -28,6 +28,9 @@ animations = [ {
 } ]
 
 [node name="DemonBatedor" type="KinematicBody2D" groups=[
+"character",
+"batedor",
+"demon",
 "enemy",
 ]]
 script = ExtResource( 1 )
@@ -38,6 +41,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 1
+frame = 3
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Demons/DemonBatedor.tscn
+++ b/Objects/Foes/Demons/DemonBatedor.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="DemonBatedor" type="KinematicBody2D"]
+[node name="DemonBatedor" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,6 +38,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 3
+frame = 1
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Demons/DemonBoss.tscn
+++ b/Objects/Foes/Demons/DemonBoss.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="DemonBoss" type="KinematicBody2D"]
+[node name="DemonBoss" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Foes/Demons/DemonBoss.tscn
+++ b/Objects/Foes/Demons/DemonBoss.tscn
@@ -28,6 +28,9 @@ animations = [ {
 } ]
 
 [node name="DemonBoss" type="KinematicBody2D" groups=[
+"character",
+"demon",
+"boss",
 "enemy",
 ]]
 script = ExtResource( 1 )

--- a/Objects/Foes/Demons/DemonPerseguidor.tscn
+++ b/Objects/Foes/Demons/DemonPerseguidor.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="DemonPerseguidor" type="KinematicBody2D"]
+[node name="DemonPerseguidor" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,6 +38,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 3
+frame = 2
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Demons/DemonPerseguidor.tscn
+++ b/Objects/Foes/Demons/DemonPerseguidor.tscn
@@ -28,6 +28,9 @@ animations = [ {
 } ]
 
 [node name="DemonPerseguidor" type="KinematicBody2D" groups=[
+"character",
+"demon",
+"perseguidor",
 "enemy",
 ]]
 script = ExtResource( 1 )
@@ -38,6 +41,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 2
+frame = 3
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Demons/DemonTanker.tscn
+++ b/Objects/Foes/Demons/DemonTanker.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="DemonTanker" type="KinematicBody2D"]
+[node name="DemonTanker" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,6 +38,5 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 3
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Demons/DemonTanker.tscn
+++ b/Objects/Foes/Demons/DemonTanker.tscn
@@ -28,6 +28,9 @@ animations = [ {
 } ]
 
 [node name="DemonTanker" type="KinematicBody2D" groups=[
+"character",
+"tanker",
+"demon",
 "enemy",
 ]]
 script = ExtResource( 1 )
@@ -38,5 +41,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
+frame = 2
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Demons/DemonXama.tscn
+++ b/Objects/Foes/Demons/DemonXama.tscn
@@ -28,6 +28,9 @@ animations = [ {
 } ]
 
 [node name="DemonXama" type="KinematicBody2D" groups=[
+"character",
+"xama",
+"demon",
 "enemy",
 ]]
 script = ExtResource( 1 )
@@ -38,6 +41,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 1
+frame = 3
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Demons/DemonXama.tscn
+++ b/Objects/Foes/Demons/DemonXama.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="DemonXama" type="KinematicBody2D"]
+[node name="DemonXama" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,6 +38,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 2
+frame = 1
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Orcs/OrcBatedor.tscn
+++ b/Objects/Foes/Orcs/OrcBatedor.tscn
@@ -28,6 +28,9 @@ animations = [ {
 } ]
 
 [node name="OrcBatedor" type="KinematicBody2D" groups=[
+"character",
+"orc",
+"batedor",
 "enemy",
 ]]
 script = ExtResource( 1 )

--- a/Objects/Foes/Orcs/OrcBatedor.tscn
+++ b/Objects/Foes/Orcs/OrcBatedor.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="OrcBatedor" type="KinematicBody2D"]
+[node name="OrcBatedor" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Foes/Orcs/OrcBoss.tscn
+++ b/Objects/Foes/Orcs/OrcBoss.tscn
@@ -28,7 +28,10 @@ animations = [ {
 } ]
 
 [node name="OrcBoss" type="KinematicBody2D" groups=[
+"character",
 "enemy",
+"orc",
+"boss",
 ]]
 script = ExtResource( 1 )
 
@@ -38,6 +41,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "idle"
-frame = 3
+frame = 2
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Orcs/OrcBoss.tscn
+++ b/Objects/Foes/Orcs/OrcBoss.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="OrcBoss" type="KinematicBody2D"]
+[node name="OrcBoss" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,6 +38,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "idle"
-frame = 2
+frame = 3
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Orcs/OrcPerseguidor.tscn
+++ b/Objects/Foes/Orcs/OrcPerseguidor.tscn
@@ -27,6 +27,9 @@ animations = [ {
 } ]
 
 [node name="OrcPerseguidor" type="KinematicBody2D" groups=[
+"character",
+"orc",
+"perseguidor",
 "enemy",
 ]]
 script = ExtResource( 1 )
@@ -37,6 +40,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "idle"
-frame = 3
+frame = 1
 playing = true
 offset = Vector2( 0, -3 )

--- a/Objects/Foes/Orcs/OrcPerseguidor.tscn
+++ b/Objects/Foes/Orcs/OrcPerseguidor.tscn
@@ -26,7 +26,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="OrcPerseguidor" type="KinematicBody2D"]
+[node name="OrcPerseguidor" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Foes/Orcs/OrcTanker.tscn
+++ b/Objects/Foes/Orcs/OrcTanker.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="OrcTanker" type="KinematicBody2D"]
+[node name="OrcTanker" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,6 +38,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "idle"
-frame = 2
+frame = 1
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Orcs/OrcTanker.tscn
+++ b/Objects/Foes/Orcs/OrcTanker.tscn
@@ -28,6 +28,9 @@ animations = [ {
 } ]
 
 [node name="OrcTanker" type="KinematicBody2D" groups=[
+"character",
+"orc",
+"tanker",
 "enemy",
 ]]
 script = ExtResource( 1 )

--- a/Objects/Foes/Orcs/OrcXama.tscn
+++ b/Objects/Foes/Orcs/OrcXama.tscn
@@ -28,7 +28,10 @@ animations = [ {
 } ]
 
 [node name="OrcXama" type="KinematicBody2D" groups=[
+"character",
 "enemy",
+"orc",
+"xama",
 ]]
 script = ExtResource( 1 )
 
@@ -38,6 +41,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "idle"
-frame = 2
+frame = 3
 playing = true
 offset = Vector2( 0, -1 )

--- a/Objects/Foes/Orcs/OrcXama.tscn
+++ b/Objects/Foes/Orcs/OrcXama.tscn
@@ -27,7 +27,9 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="OrcXama" type="KinematicBody2D"]
+[node name="OrcXama" type="KinematicBody2D" groups=[
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Foes/Undeads/UndeadBatedor.tscn
+++ b/Objects/Foes/Undeads/UndeadBatedor.tscn
@@ -27,7 +27,12 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="UndeadBatedor" type="KinematicBody2D"]
+[node name="UndeadBatedor" type="KinematicBody2D" groups=[
+"character",
+"batedor",
+"undead",
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,5 +41,6 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
+frame = 3
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Foes/Undeads/UndeadBoss.tscn
+++ b/Objects/Foes/Undeads/UndeadBoss.tscn
@@ -27,7 +27,12 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="UndeadBoss" type="KinematicBody2D"]
+[node name="UndeadBoss" type="KinematicBody2D" groups=[
+"character",
+"undead",
+"boss",
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Foes/Undeads/UndeadPerseguidor.tscn
+++ b/Objects/Foes/Undeads/UndeadPerseguidor.tscn
@@ -27,7 +27,12 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="UndeadPerseguidor" type="KinematicBody2D"]
+[node name="UndeadPerseguidor" type="KinematicBody2D" groups=[
+"character",
+"perseguidor",
+"undead",
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Foes/Undeads/UndeadTanker.tscn
+++ b/Objects/Foes/Undeads/UndeadTanker.tscn
@@ -27,7 +27,12 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="UndeadTanker" type="KinematicBody2D"]
+[node name="UndeadTanker" type="KinematicBody2D" groups=[
+"character",
+"undead",
+"tanker",
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Foes/Undeads/UndeadXama.tscn
+++ b/Objects/Foes/Undeads/UndeadXama.tscn
@@ -27,7 +27,12 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[node name="UndeadXama" type="KinematicBody2D"]
+[node name="UndeadXama" type="KinematicBody2D" groups=[
+"character",
+"undead",
+"xama",
+"enemy",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -36,6 +41,5 @@ shape = SubResource( 1 )
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 2 )
 animation = "run"
-frame = 1
 playing = true
 offset = Vector2( 0, -2 )

--- a/Objects/Players/Elf.tscn
+++ b/Objects/Players/Elf.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Scripts/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f0.png" type="Texture" id=2]
@@ -11,7 +11,7 @@
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f3.png" type="Texture" id=9]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_hit_anim_f0.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
-[ext_resource path="res://Scripts/Attack/Attack.gd" type="Script" id=12]
+[ext_resource path="res://Utils/FrontAttack.tscn" type="PackedScene" id=12]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 5.81073
@@ -35,9 +35,6 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[sub_resource type="CapsuleShape2D" id=3]
-height = 2.0
-
 [node name="Elf" type="KinematicBody2D"]
 script = ExtResource( 1 )
 
@@ -48,21 +45,9 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
+frame = 1
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]
 
-[node name="Attack" type="Node2D" parent="." groups=[
-"player",
-]]
-script = ExtResource( 12 )
-
-[node name="HitArea" type="Area2D" parent="Attack"]
-
-[node name="Shape" type="CollisionShape2D" parent="Attack/HitArea"]
-position = Vector2( 10, -1 )
-shape = SubResource( 3 )
-__meta__ = {
-"_edit_group_": true
-}
-[connection signal="body_entered" from="Attack/HitArea" to="Attack" method="_on_HitArea_body_entered"]
+[node name="FrontAttack" parent="." instance=ExtResource( 12 )]

--- a/Objects/Players/Elf.tscn
+++ b/Objects/Players/Elf.tscn
@@ -48,12 +48,13 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
-frame = 3
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]
 
-[node name="Attack" type="Node2D" parent="."]
+[node name="Attack" type="Node2D" parent="." groups=[
+"player",
+]]
 script = ExtResource( 12 )
 
 [node name="HitArea" type="Area2D" parent="Attack"]

--- a/Objects/Players/Elf.tscn
+++ b/Objects/Players/Elf.tscn
@@ -1,16 +1,17 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://Scripts/Player/Player.gd" type="Script" id=1]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f0.png" type="Texture" id=2]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_hit_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f0.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f1.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f2.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f3.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f1.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f2.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f3.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_hit_anim_f0.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
+[ext_resource path="res://Scripts/Attack/Attack.gd" type="Script" id=12]
 
 [sub_resource type="CapsuleShape2D" id=1]
 radius = 5.81073
@@ -23,16 +24,19 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ), ExtResource( 6 ), ExtResource( 6 ), ExtResource( 6 ) ],
-"loop": true,
-"name": "hit",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
 "loop": true,
 "name": "run",
 "speed": 10.0
+}, {
+"frames": [ ExtResource( 10 ), ExtResource( 10 ), ExtResource( 10 ), ExtResource( 10 ) ],
+"loop": true,
+"name": "hit",
+"speed": 10.0
 } ]
+
+[sub_resource type="CapsuleShape2D" id=3]
+height = 2.0
 
 [node name="Elf" type="KinematicBody2D"]
 script = ExtResource( 1 )
@@ -44,7 +48,20 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
-frame = 1
+frame = 3
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]
+
+[node name="Attack" type="Node2D" parent="."]
+script = ExtResource( 12 )
+
+[node name="HitArea" type="Area2D" parent="Attack"]
+
+[node name="Shape" type="CollisionShape2D" parent="Attack/HitArea"]
+position = Vector2( 10, -1 )
+shape = SubResource( 3 )
+__meta__ = {
+"_edit_group_": true
+}
+[connection signal="body_entered" from="Attack/HitArea" to="Attack" method="_on_HitArea_body_entered"]

--- a/Objects/Players/Elf.tscn
+++ b/Objects/Players/Elf.tscn
@@ -5,11 +5,11 @@
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/elf_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f1.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f2.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f3.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/elf_m_hit_anim_f0.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_hit_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f0.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f1.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f2.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/elf_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
 [ext_resource path="res://Utils/FrontAttack.tscn" type="PackedScene" id=12]
 
@@ -24,18 +24,22 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
-"loop": true,
-"name": "run",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 10 ), ExtResource( 10 ), ExtResource( 10 ), ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ), ExtResource( 6 ), ExtResource( 6 ), ExtResource( 6 ) ],
 "loop": true,
 "name": "hit",
 "speed": 10.0
+}, {
+"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"loop": true,
+"name": "run",
+"speed": 10.0
 } ]
 
-[node name="Elf" type="KinematicBody2D"]
+[node name="Elf" type="KinematicBody2D" groups=[
+"character",
+"player",
+"elf",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -45,7 +49,7 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
-frame = 1
+frame = 2
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]

--- a/Objects/Players/Knight.tscn
+++ b/Objects/Players/Knight.tscn
@@ -5,11 +5,11 @@
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_hit_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f0.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f1.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f2.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f3.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f1.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f2.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f3.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_hit_anim_f0.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
 
 [sub_resource type="CapsuleShape2D" id=1]
@@ -23,18 +23,20 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ) ],
-"loop": true,
-"name": "hit",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
 "loop": true,
 "name": "run",
 "speed": 10.0
+}, {
+"frames": [ ExtResource( 10 ) ],
+"loop": true,
+"name": "hit",
+"speed": 10.0
 } ]
 
-[node name="Knight" type="KinematicBody2D"]
+[node name="Knight" type="KinematicBody2D" groups=[
+"player",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -44,6 +46,7 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
+frame = 2
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]

--- a/Objects/Players/Knight.tscn
+++ b/Objects/Players/Knight.tscn
@@ -5,11 +5,11 @@
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/knight_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f1.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f2.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f3.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/knight_m_hit_anim_f0.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_hit_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f0.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f1.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f2.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/knight_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
 
 [sub_resource type="CapsuleShape2D" id=1]
@@ -23,19 +23,21 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
-"loop": true,
-"name": "run",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ) ],
 "loop": true,
 "name": "hit",
+"speed": 10.0
+}, {
+"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"loop": true,
+"name": "run",
 "speed": 10.0
 } ]
 
 [node name="Knight" type="KinematicBody2D" groups=[
+"character",
 "player",
+"knight",
 ]]
 script = ExtResource( 1 )
 

--- a/Objects/Players/Lizard.tscn
+++ b/Objects/Players/Lizard.tscn
@@ -5,11 +5,11 @@
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f1.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f2.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f3.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_hit_anim_f0.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_hit_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f0.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f1.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f2.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
 
 [sub_resource type="CapsuleShape2D" id=1]
@@ -23,19 +23,21 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
-"loop": true,
-"name": "run",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ) ],
 "loop": true,
 "name": "hit",
+"speed": 10.0
+}, {
+"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"loop": true,
+"name": "run",
 "speed": 10.0
 } ]
 
 [node name="Lizard" type="KinematicBody2D" groups=[
+"character",
 "player",
+"lizard",
 ]]
 script = ExtResource( 1 )
 
@@ -46,7 +48,6 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
-frame = 1
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]

--- a/Objects/Players/Lizard.tscn
+++ b/Objects/Players/Lizard.tscn
@@ -5,11 +5,11 @@
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/lizard_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_hit_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f0.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f1.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f2.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f3.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f1.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f2.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_run_anim_f3.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/lizard_m_hit_anim_f0.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
 
 [sub_resource type="CapsuleShape2D" id=1]
@@ -23,18 +23,20 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ) ],
-"loop": true,
-"name": "hit",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
 "loop": true,
 "name": "run",
 "speed": 10.0
+}, {
+"frames": [ ExtResource( 10 ) ],
+"loop": true,
+"name": "hit",
+"speed": 10.0
 } ]
 
-[node name="Lizard" type="KinematicBody2D"]
+[node name="Lizard" type="KinematicBody2D" groups=[
+"player",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Objects/Players/Wizard.tscn
+++ b/Objects/Players/Wizard.tscn
@@ -5,11 +5,11 @@
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_hit_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f0.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f1.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f2.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f3.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f1.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f2.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f3.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_hit_anim_f0.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
 
 [sub_resource type="CapsuleShape2D" id=1]
@@ -23,18 +23,20 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ) ],
-"loop": true,
-"name": "hit",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
 "loop": true,
 "name": "run",
 "speed": 10.0
+}, {
+"frames": [ ExtResource( 10 ) ],
+"loop": true,
+"name": "hit",
+"speed": 10.0
 } ]
 
-[node name="Wizard" type="KinematicBody2D"]
+[node name="Wizard" type="KinematicBody2D" groups=[
+"player",
+]]
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
@@ -44,7 +46,7 @@ shape = SubResource( 1 )
 position = Vector2( 0, -4 )
 frames = SubResource( 2 )
 animation = "idle"
-frame = 3
+frame = 2
 playing = true
 
 [node name="Movement" parent="." instance=ExtResource( 11 )]

--- a/Objects/Players/Wizard.tscn
+++ b/Objects/Players/Wizard.tscn
@@ -5,11 +5,11 @@
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_idle_anim_f1.png" type="Texture" id=3]
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_idle_anim_f2.png" type="Texture" id=4]
 [ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_idle_anim_f3.png" type="Texture" id=5]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f0.png" type="Texture" id=6]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f1.png" type="Texture" id=7]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f2.png" type="Texture" id=8]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f3.png" type="Texture" id=9]
-[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_hit_anim_f0.png" type="Texture" id=10]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_hit_anim_f0.png" type="Texture" id=6]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f0.png" type="Texture" id=7]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f1.png" type="Texture" id=8]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f2.png" type="Texture" id=9]
+[ext_resource path="res://Sprites/Characters/Bodies/wizzard_m_run_anim_f3.png" type="Texture" id=10]
 [ext_resource path="res://Utils/KeyboardMovement.tscn" type="PackedScene" id=11]
 
 [sub_resource type="CapsuleShape2D" id=1]
@@ -23,19 +23,21 @@ animations = [ {
 "name": "idle",
 "speed": 10.0
 }, {
-"frames": [ ExtResource( 6 ), ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ) ],
-"loop": true,
-"name": "run",
-"speed": 10.0
-}, {
-"frames": [ ExtResource( 10 ) ],
+"frames": [ ExtResource( 6 ) ],
 "loop": true,
 "name": "hit",
+"speed": 10.0
+}, {
+"frames": [ ExtResource( 7 ), ExtResource( 8 ), ExtResource( 9 ), ExtResource( 10 ) ],
+"loop": true,
+"name": "run",
 "speed": 10.0
 } ]
 
 [node name="Wizard" type="KinematicBody2D" groups=[
+"character",
 "player",
+"wizard",
 ]]
 script = ExtResource( 1 )
 

--- a/Scripts/Attack/Attack.gd
+++ b/Scripts/Attack/Attack.gd
@@ -1,12 +1,53 @@
 extends Node
 
-var strength = 0
+export var strength = 0
+export var animation_time = 0.5
+export var cooldown = 1
+
+onready var hit_area = $HitArea
+
+func _ready():
+	# inicia o jogo sem que esteja atacando, ie, remove o nó de ataque
+	stop_attacking()
+
+func _process(delta):
+	if attack_button_pressed() && !is_in_cooldown():
+		attack()
+
+func attack_button_pressed() -> bool:
+	# está como padrão a tecla de "ui_accept"
+	# é possivel alterar para outra tecla ou até deixar algo parametrizável
+	return Input.is_action_just_pressed("ui_accept")
+
+func is_in_cooldown() -> bool:
+	# TODO
+	# essa função deve retornar true caso o ataque esteja em cooldown e falso caso contrário
+	# está sempre retornando falso podermos testar enquanto ainda nao foi implementato
+	return false
+	
+func attack():
+	# insere o nó da area de hit
+	add_child(hit_area)
+	# inicia o cooldown da animação do ataque
+	$AnimationCooldown.start(animation_time)
+	
+func stop_attacking():
+	# remove o nó que segura a área de hit
+	remove_child(hit_area)
+
+func is_hitting() -> bool:
+	return !$AnimationCooldown.is_stopped()
 
 func _on_HitArea_body_entered(body):
-	print ("opa um maluco entrou aqui")
-	print (body)
-	
-	# here it should try cause damage to de body
-	# body.take_damage(strength)
-	# maybe it should filter the bodies, like being just enemies instead of any body
-	# if body.is_an_enemy:
+	if body.is_in_group("enemy"):
+		# tecnicas avançadas de debug
+		print ("opa um maluco entrou aqui")
+		print (body)
+		# deve causar dano ao body
+		# assumindo que o método take_damage está implementado
+		# deve aparecer algo como:
+		# body.take_damage(strength)
+
+func _on_AnimationCooldown_timeout():
+	stop_attacking()
+	pass

--- a/Scripts/Attack/Attack.gd
+++ b/Scripts/Attack/Attack.gd
@@ -1,0 +1,12 @@
+extends Node
+
+var strength = 0
+
+func _on_HitArea_body_entered(body):
+	print ("opa um maluco entrou aqui")
+	print (body)
+	
+	# here it should try cause damage to de body
+	# body.take_damage(strength)
+	# maybe it should filter the bodies, like being just enemies instead of any body
+	# if body.is_an_enemy:

--- a/Scripts/Attack/Attack.gd
+++ b/Scripts/Attack/Attack.gd
@@ -4,50 +4,45 @@ export var strength = 0
 export var animation_time = 0.5
 export var cooldown = 1
 
+onready var character = get_parent()
 onready var hit_area = $HitArea
 
 func _ready():
-	# inicia o jogo sem que esteja atacando, ie, remove o nó de ataque
 	stop_attacking()
 
 func _process(delta):
-	if attack_button_pressed() && !is_in_cooldown():
+	if  attack_button_pressed() && !is_attacking() && !is_in_cooldown():
 		attack()
 
-func attack_button_pressed() -> bool:
-	# está como padrão a tecla de "ui_accept"
-	# é possivel alterar para outra tecla ou até deixar algo parametrizável
-	return Input.is_action_just_pressed("ui_accept")
-
-func is_in_cooldown() -> bool:
-	# TODO
-	# essa função deve retornar true caso o ataque esteja em cooldown e falso caso contrário
-	# está sempre retornando falso podermos testar enquanto ainda nao foi implementato
-	return false
-	
 func attack():
-	# insere o nó da area de hit
 	add_child(hit_area)
-	# inicia o cooldown da animação do ataque
+	var shape=$HitArea/Shape.shape
+	if character.facing=="left":
+		hit_area.position=Vector2(-shape.radius,0)
+	elif character.facing=="right":
+		hit_area.position=Vector2(shape.radius,0)
 	$AnimationCooldown.start(animation_time)
 	
 func stop_attacking():
-	# remove o nó que segura a área de hit
 	remove_child(hit_area)
+	$AttackCooldown.start(cooldown)
 
-func is_hitting() -> bool:
+func is_in_cooldown() -> bool:
+	return !$AttackCooldown.is_stopped()
+	
+func is_attacking() -> bool:
 	return !$AnimationCooldown.is_stopped()
 
+func attack_button_pressed() -> bool:
+	return Input.is_action_just_pressed("ui_accept")
+	
 func _on_HitArea_body_entered(body):
 	if body.is_in_group("enemy"):
-		# tecnicas avançadas de debug
-		print ("opa um maluco entrou aqui")
-		print (body)
 		# deve causar dano ao body
 		# assumindo que o método take_damage está implementado
 		# deve aparecer algo como:
 		# body.take_damage(strength)
+		pass
 
 func _on_AnimationCooldown_timeout():
 	stop_attacking()
-	pass

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -1,10 +1,14 @@
 extends KinematicBody2D
 
+export var facing:String
+
 func _process(delta):
 	if Input.is_action_pressed("ui_left"):
+		facing="left"
 		$AnimatedSprite.animation = "run"
 		$AnimatedSprite.flip_h = true
 	elif Input.is_action_pressed("ui_right"):
+		facing="right"
 		$AnimatedSprite.animation = "run"
 		$AnimatedSprite.flip_h = false
 	else:

--- a/Scripts/Player/Player.gd
+++ b/Scripts/Player/Player.gd
@@ -1,6 +1,6 @@
 extends KinematicBody2D
 
-export var facing:String
+export var facing="right"
 
 func _process(delta):
 	if Input.is_action_pressed("ui_left"):

--- a/Utils/FrontAttack.tscn
+++ b/Utils/FrontAttack.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://Scripts/Attack/Attack.gd" type="Script" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+
+[node name="FrontAttack" type="Node2D" groups=[
+"player",
+]]
+script = ExtResource( 1 )
+
+[node name="HitArea" type="Area2D" parent="."]
+
+[node name="Shape" type="CollisionShape2D" parent="HitArea"]
+position = Vector2( 10, 0 )
+shape = SubResource( 1 )
+__meta__ = {
+"_edit_group_": true
+}
+
+[node name="AttackCooldown" type="Timer" parent="."]
+one_shot = true
+
+[node name="AnimationCooldown" type="Timer" parent="."]
+one_shot = true
+[connection signal="body_entered" from="HitArea" to="." method="_on_HitArea_body_entered"]
+[connection signal="timeout" from="AnimationCooldown" to="." method="_on_AnimationCooldown_timeout"]

--- a/Utils/FrontAttack.tscn
+++ b/Utils/FrontAttack.tscn
@@ -12,7 +12,6 @@ script = ExtResource( 1 )
 [node name="HitArea" type="Area2D" parent="."]
 
 [node name="Shape" type="CollisionShape2D" parent="HitArea"]
-position = Vector2( 10, 0 )
 shape = SubResource( 1 )
 __meta__ = {
 "_edit_group_": true


### PR DESCRIPTION
## FrontAttack.gd
Foi criado um script responsável pelos ataques dos jogadores, anexado a uma cena com nós para área de ataque e cooldown. O script faz uma checagem constante dos estados dos timers e os utiliza para permitir ou não a ação de ataque pelo jogador, além de checar se o tipo (grupo) de um alvo que entre na área do ataque o classifica como "inimigo" ou não. O script pode ser acessado a partir da cena localizada em `Utils/FrontAttak.tscn`
## Grupos
Todos os personagens foram, também, divididos em grupos que especificassem seus tipos, sendo estes: `character`, `player`, `enemy`, `demon`, `elf`, `knight`, `lizard`, `wizard`, `undead`, `orc`, `batedor`, `perseguidor`, `tanker`, `boss`, `xama`.